### PR TITLE
Fix modulo mobile performance: idle audio DSP, node leaks, DOM churn

### DIFF
--- a/machines/modulo/src/Drums.ts
+++ b/machines/modulo/src/Drums.ts
@@ -107,35 +107,17 @@ const DEFAULT_KICK_SETTINGS: ConfigurableKickParams = {
   },
 };
 
-export class ConfigurableHat {
-  type: Extract<DrumKitKey, "closed" | "open">;
-  closed: boolean;
-  node: NoiseSynth;
+abstract class ConfigurableDrum<P extends DrumParams> {
   output: Gain;
   highpass: Filter;
   lowpass: Filter;
-  crush: BitCrusher;
-  delay: FeedbackDelay;
-  params: ConfigurableHatParams;
+  crush?: BitCrusher;
+  delay?: FeedbackDelay;
+  params: P;
 
-  static initialSettings(type: Extract<DrumKitKey, "closed" | "open">) {
-    return { type, ...DEFAULT_HAT_SETTINGS };
-  }
-
-  constructor(params: ConfigurableHatParams) {
-    this.type = params.type;
+  constructor(params: P) {
     this.params = params;
-    this.node = new NoiseSynth();
     this.output = new Gain(params.volume);
-
-    // Set fixed envelope and noise settings
-    this.node.noise.type = "white";
-    this.node.envelope.attack = 0.0001;
-    this.node.envelope.decay = params.type === "closed" ? 0.17 : 0.27;
-    this.node.envelope.sustain = params.type === "closed" ? 0 : 0.1;
-    this.node.envelope.release = params.type === "closed" ? 0.05 : 0.5;
-
-    // Initialize effects
     this.highpass = new Filter({
       type: "highpass",
       ...params.settings.highpass,
@@ -144,15 +126,29 @@ export class ConfigurableHat {
       type: "lowpass",
       ...params.settings.lowpass,
     });
-    this.crush = new BitCrusher(params.settings.crush);
-    this.delay = new FeedbackDelay(params.settings.delay);
-
-    // Connect effects chain
-    this.node.connect(this.highpass);
     this.highpass.connect(this.lowpass);
-    this.lowpass.connect(this.crush);
-    this.crush.connect(this.delay);
-    this.delay.connect(this.output);
+    this.rewireEffects();
+  }
+
+  // The bit crusher (an audio worklet) and delay only exist and process audio
+  // while their wet amount is non-zero — both are expensive on mobile.
+  private rewireEffects() {
+    this.lowpass.disconnect();
+    this.crush?.disconnect();
+    this.delay?.disconnect();
+    let tail: Filter | BitCrusher | FeedbackDelay = this.lowpass;
+    if (this.params.settings.crush.wet > 0) {
+      if (!this.crush) this.crush = new BitCrusher(this.params.settings.crush);
+      tail.connect(this.crush);
+      tail = this.crush;
+    }
+    if (this.params.settings.delay.wet > 0) {
+      if (!this.delay)
+        this.delay = new FeedbackDelay(this.params.settings.delay);
+      tail.connect(this.delay);
+      tail = this.delay;
+    }
+    tail.connect(this.output);
   }
 
   updateSettings(params: DrumParams) {
@@ -160,14 +156,15 @@ export class ConfigurableHat {
       ...this.params,
       ...params,
       settings: { ...this.params.settings, ...params.settings },
-    };
-    this.highpass.set(params.settings.highpass);
-    this.lowpass.set(params.settings.lowpass);
-    this.crush.set(params.settings.crush);
-    this.delay.set(params.settings.delay);
+    } as P;
+    this.highpass.set(this.params.settings.highpass);
+    this.lowpass.set(this.params.settings.lowpass);
+    this.crush?.set(this.params.settings.crush);
+    this.delay?.set(this.params.settings.delay);
+    this.rewireEffects();
   }
 
-  exportParams() {
+  exportParams(): P {
     return this.params;
   }
 
@@ -180,32 +177,70 @@ export class ConfigurableHat {
     return (this.output.gain.value = value);
   }
 
+  dispose() {
+    this.disposeSources();
+    this.highpass.dispose();
+    this.lowpass.dispose();
+    this.crush?.dispose();
+    this.crush = undefined;
+    this.delay?.dispose();
+    this.delay = undefined;
+    this.output.dispose();
+  }
+
+  protected abstract disposeSources(): void;
+  abstract play(velocity: number | null, time: number): void;
+}
+
+export class ConfigurableHat extends ConfigurableDrum<ConfigurableHatParams> {
+  type: Extract<DrumKitKey, "closed" | "open">;
+  node: NoiseSynth;
+
+  static initialSettings(type: Extract<DrumKitKey, "closed" | "open">) {
+    return { type, ...DEFAULT_HAT_SETTINGS };
+  }
+
+  constructor(params: ConfigurableHatParams) {
+    super(params);
+    this.type = params.type;
+    this.node = new NoiseSynth();
+
+    // Set fixed envelope and noise settings
+    this.node.noise.type = "white";
+    this.node.envelope.attack = 0.0001;
+    this.node.envelope.decay = params.type === "closed" ? 0.17 : 0.27;
+    this.node.envelope.sustain = params.type === "closed" ? 0 : 0.1;
+    this.node.envelope.release = params.type === "closed" ? 0.05 : 0.5;
+
+    this.node.connect(this.highpass);
+  }
+
+  protected disposeSources() {
+    this.node.dispose();
+  }
+
   play(velocity: number | null, time: number) {
     if (velocity === null) return;
     this.node.triggerAttackRelease("16n", time, velocity);
   }
 }
 
-export class ConfigurableSnare {
+export class ConfigurableSnare extends ConfigurableDrum<ConfigurableSnareParams> {
   type: Extract<DrumKitKey, "snare">;
   node1: Synth;
   node2: NoiseSynth;
-  output: Gain;
-  highpass: Filter;
-  lowpass: Filter;
-  crush: BitCrusher;
-  delay: FeedbackDelay;
-  params: ConfigurableSnareParams;
+  private toneChain: Gain;
+  private noiseChain: Gain;
 
   static get initialSettings() {
     return DEFAULT_SNARE_SETTINGS;
   }
 
   constructor(params: ConfigurableSnareParams) {
-    this.params = params;
+    super(params);
+    this.type = params.type;
     this.node1 = new Synth();
     this.node2 = new NoiseSynth();
-    this.output = new Gain(params.volume);
 
     // Set fixed synth settings
     this.node1.oscillator.type = "sine";
@@ -223,60 +258,21 @@ export class ConfigurableSnare {
     this.node2.envelope.sustain = 0;
     this.node2.envelope.release = 0.03;
 
-    // Initialize effects
-    this.highpass = new Filter({
-      type: "highpass",
-      ...params.settings.highpass,
-    });
-    this.lowpass = new Filter({
-      type: "lowpass",
-      ...params.settings.lowpass,
-    });
-    this.crush = new BitCrusher(params.settings.crush);
-    this.delay = new FeedbackDelay(params.settings.delay);
-
     // Create parallel paths for tone and noise
-    const toneChain = new Gain(1);
-    const noiseChain = new Gain(0.5);
+    this.toneChain = new Gain(1);
+    this.noiseChain = new Gain(0.5);
 
-    // Connect tone path
-    this.node1.connect(toneChain);
-    toneChain.connect(this.highpass);
-
-    // Connect noise path
-    this.node2.connect(noiseChain);
-    noiseChain.connect(this.highpass);
-
-    // Connect shared effects chain
-    this.highpass.connect(this.lowpass);
-    this.lowpass.connect(this.crush);
-    this.crush.connect(this.delay);
-    this.delay.connect(this.output);
+    this.node1.connect(this.toneChain);
+    this.toneChain.connect(this.highpass);
+    this.node2.connect(this.noiseChain);
+    this.noiseChain.connect(this.highpass);
   }
 
-  updateSettings(params: DrumParams) {
-    this.params = {
-      ...this.params,
-      ...params,
-      settings: { ...this.params.settings, ...params.settings },
-    };
-    this.highpass.set(params.settings.highpass);
-    this.lowpass.set(params.settings.lowpass);
-    this.crush.set(params.settings.crush);
-    this.delay.set(params.settings.delay);
-  }
-
-  exportParams() {
-    return this.params;
-  }
-
-  getGain() {
-    return this.output.gain.value;
-  }
-
-  updateGain(value: number) {
-    this.params.volume = value;
-    return (this.output.gain.value = value);
+  protected disposeSources() {
+    this.node1.dispose();
+    this.node2.dispose();
+    this.toneChain.dispose();
+    this.noiseChain.dispose();
   }
 
   play(velocity: number | null, time: number) {
@@ -288,26 +284,22 @@ export class ConfigurableSnare {
   }
 }
 
-export class ConfigurableKick {
+export class ConfigurableKick extends ConfigurableDrum<ConfigurableKickParams> {
   type: Extract<DrumKitKey, "kick">;
   node1: MembraneSynth;
   node2: NoiseSynth;
-  output: Gain;
-  highpass: Filter;
-  lowpass: Filter;
-  crush: BitCrusher;
-  delay: FeedbackDelay;
-  params: ConfigurableKickParams;
+  private membraneChain: Gain;
+  private noiseChain: Gain;
 
   static get initialSettings() {
     return DEFAULT_KICK_SETTINGS;
   }
 
   constructor(params: ConfigurableKickParams) {
-    this.params = params;
+    super(params);
+    this.type = params.type;
     this.node1 = new MembraneSynth();
     this.node2 = new NoiseSynth();
-    this.output = new Gain(params.volume);
 
     // Set fixed envelope settings
     this.node1.envelope.attack = 0.001;
@@ -322,60 +314,21 @@ export class ConfigurableKick {
     this.node2.envelope.sustain = 0;
     this.node2.envelope.release = 0.03;
 
-    // Initialize effects
-    this.highpass = new Filter({
-      type: "highpass",
-      ...params.settings.highpass,
-    });
-    this.lowpass = new Filter({
-      type: "lowpass",
-      ...params.settings.lowpass,
-    });
-    this.crush = new BitCrusher(params.settings.crush);
-    this.delay = new FeedbackDelay(params.settings.delay);
-
     // Create parallel paths for membrane and noise
-    const membraneChain = new Gain(1);
-    const noiseChain = new Gain(0.2);
+    this.membraneChain = new Gain(1);
+    this.noiseChain = new Gain(0.2);
 
-    // Connect membrane path
-    this.node1.connect(membraneChain);
-    membraneChain.connect(this.highpass);
-
-    // Connect noise path
-    this.node2.connect(noiseChain);
-    noiseChain.connect(this.highpass);
-
-    // Connect shared effects chain
-    this.highpass.connect(this.lowpass);
-    this.lowpass.connect(this.crush);
-    this.crush.connect(this.delay);
-    this.delay.connect(this.output);
+    this.node1.connect(this.membraneChain);
+    this.membraneChain.connect(this.highpass);
+    this.node2.connect(this.noiseChain);
+    this.noiseChain.connect(this.highpass);
   }
 
-  updateSettings(params: DrumParams) {
-    this.params = {
-      ...this.params,
-      ...params,
-      settings: { ...this.params.settings, ...params.settings },
-    };
-    this.highpass.set(params.settings.highpass);
-    this.lowpass.set(params.settings.lowpass);
-    this.crush.set(params.settings.crush);
-    this.delay.set(params.settings.delay);
-  }
-
-  getGain() {
-    return this.output.gain.value;
-  }
-
-  updateGain(value: number) {
-    this.params.volume = value;
-    return (this.output.gain.value = value);
-  }
-
-  exportParams() {
-    return this.params;
+  protected disposeSources() {
+    this.node1.dispose();
+    this.node2.dispose();
+    this.membraneChain.dispose();
+    this.noiseChain.dispose();
   }
 
   play(velocity: number | null, time: number) {
@@ -427,17 +380,19 @@ export class Drums {
   }
 
   updateSettings({ type, settings }: DrumTypeSettings) {
-    this.kit[type].updateSettings(settings);
+    this.kit.find((drum) => drum.type === type)?.updateSettings(settings);
   }
 
   dispose() {
-    Object.values(this.kit).forEach((item) => item.output.dispose());
+    this.kit.forEach((item) => item.dispose());
+    this.output?.dispose();
+    this.output = undefined;
   }
 
   exportParams(): DrumsParams {
     const settings = this.kit.map((a) => a.exportParams());
     return {
-      volume: this.output?.gain.value || 0,
+      volume: this.output ? this.output.gain.value : this.volume,
       settings,
     };
   }
@@ -449,10 +404,11 @@ export class Drums {
   }
 
   getGain() {
-    return this.output?.gain.value || 0;
+    return this.output ? this.output.gain.value : this.volume;
   }
 
   updateGain(gain: number) {
+    this.volume = gain;
     if (this.output) {
       this.output.gain.value = gain;
     }

--- a/machines/modulo/src/Machine.ts
+++ b/machines/modulo/src/Machine.ts
@@ -1,3 +1,4 @@
+import { getDraw } from "tone";
 import { Clock, ClockParams } from "./Clock";
 import { Destinations } from "./destinations/Destinations";
 import { Drums } from "./Drums";
@@ -286,7 +287,9 @@ export class Machine {
   }
 
   handleTick(position: number, time: number) {
-    this.renderer.renderStep(position);
+    // The transport callback runs ahead of the audible beat and must stay
+    // tight for note scheduling — paint the step via Draw at the audible time.
+    getDraw().schedule(() => this.renderer.renderStep(position), time);
     this.sequencers.forEach((sequencer) => {
       const seqValues = sequencer.steps.values(position);
       if (sequencer.isSynth()) {
@@ -358,8 +361,7 @@ export class Machine {
   }
 
   onToggleRainbow() {
-    this.renderer.hueRotate = !this.renderer.hueRotate;
-    return this.renderer.hueRotate;
+    return this.renderer.toggleHueRotate();
   }
 
   onMidiEvent(data: MIDIEvent) {
@@ -456,7 +458,7 @@ export class Machine {
       if (sequencer) {
         sequencer.steps.tap(valueA, valueB);
         this.renderer.updateStep(
-          this.renderer.sequencerElements[sequencer.key],
+          sequencer.key,
           valueA,
           valueB,
           sequencer.steps.values(valueB)[valueA],

--- a/machines/modulo/src/Renderer.ts
+++ b/machines/modulo/src/Renderer.ts
@@ -54,11 +54,14 @@ export interface RendererTheme {
 export class Renderer {
   cursorX: number | null = null;
   cursorY: number | null = null;
-  baseHue = 0;
   hueRotate = false;
   elementMain = document.createElement("main");
   elementRoot: HTMLElement;
   sequencerElements: { [key: string]: HTMLDivElement } = {};
+  sequencerButtons: { [key: string]: HTMLButtonElement[][] } = {};
+  activeColumns: { [key: string]: number | null } = {};
+  keyButtons: HTMLButtonElement[] = [];
+  padButtons: HTMLButtonElement[] = [];
   sequencers: Sequencer[] = [];
   keys: Keyboard;
   elementKeys = document.createElement("div");
@@ -96,22 +99,14 @@ export class Renderer {
     this.elementMain.appendChild(this.elementKeys);
     this.initializePads();
     this.initializeKeys();
-    this.animationLoop();
   }
 
-  animationLoop() {
-    requestAnimationFrame(this.animationLoop.bind(this));
-    if (this.hueRotate) {
-      this.baseHue += 1;
-      window.document.documentElement.style.setProperty(
-        "--color-hue-base",
-        this.baseHue.toString()
-      );
-    } else if (
-      window.document.documentElement.style.getPropertyValue("--color-hue-base")
-    ) {
-      window.document.documentElement.style.removeProperty("--color-hue-base");
-    }
+  // Rainbow mode is a compositor-friendly CSS hue-rotate animation — updating
+  // a hue custom property from script forced a full-page style recalc per frame.
+  toggleHueRotate() {
+    this.hueRotate = !this.hueRotate;
+    document.documentElement.classList.toggle("rainbow", this.hueRotate);
+    return this.hueRotate;
   }
 
   update({
@@ -200,13 +195,14 @@ export class Renderer {
     }
 
     // TODO: This clearing of theme is overkill, but fix for the fact that themes can be added and removed;
-    this.style.innerHTML = "";
+    const rules: string[] = [];
     theme.colors.forEach((color, i) => {
       for (let item in color) {
         setColor([i.toString(), item], theme.colors[i][item]);
       }
-      this.addTheme(`theme-key-${i}`, `${i}`);
+      rules.push(this.themeRule(`theme-key-${i}`, `${i}`));
     });
+    this.style.textContent = rules.join("\n");
 
     for (let type in theme.sizes) {
       const object = theme.sizes[type];
@@ -235,14 +231,14 @@ export class Renderer {
     return button;
   }
 
-  addTheme(themeClassName: string, propertyPrefix: string) {
+  themeRule(themeClassName: string, propertyPrefix: string) {
     const properties = ["b", "a", "c"].flatMap((type) =>
       ["lit", "chr", "hue"].map(
         (lch) =>
           `--color-${type}-${lch}: var(--color-${propertyPrefix}-${type}-${lch})`
       )
     );
-    this.style.innerHTML += `.${themeClassName} { ${properties.join("; ")} } `;
+    return `.${themeClassName} { ${properties.join("; ")} }`;
   }
 
   refreshTheme() {
@@ -253,11 +249,14 @@ export class Renderer {
         sequencer.isDrum() ? "drum" : "synth"
       } theme-key-${sequencer.theme}`;
     });
-    this.elementKeys.classList.add(`theme-key-${this.keys.theme}`);
-    this.elementPads.classList.add(`theme-key-${this.core.theme}`);
+    this.elementKeys.className = `theme-key-${this.keys.theme}`;
+    this.elementPads.className = `theme-key-${this.core.theme}`;
   }
 
   initializeSequencers() {
+    this.sequencerElements = {};
+    this.sequencerButtons = {};
+    this.activeColumns = {};
     this.sequencers.forEach((sequencer) => {
       const element = document.createElement("div");
       element.id = `sequencer-${sequencer.key}`;
@@ -272,8 +271,10 @@ export class Renderer {
   initializeKeys() {
     this.elementKeys.id = "keys";
     this.elementKeys.classList.add(`theme-key-${this.keys.theme}`);
+    this.keyButtons = [];
     for (let i = 0; i < 24; i++) {
       const key = document.createElement("button");
+      this.keyButtons.push(key);
       key.addEventListener("click", () => {
         this.rendererEventHandler("TAP", "KEYS", i);
       });
@@ -309,8 +310,10 @@ export class Renderer {
   initializePads() {
     this.elementPads.id = "pads";
     this.elementPads.classList.add(`theme-key-${this.core.theme}`);
+    this.padButtons = [];
     for (let i = 0; i < 8; i++) {
       const pad = this.createButton("TAP", "PADS", i);
+      this.padButtons.push(pad);
       this.elementPads.appendChild(pad);
       pad.setAttribute("state", i === 7 ? "1/4" : "0");
     }
@@ -421,21 +424,15 @@ export class Renderer {
   updateKeyboard() {
     const { stepsForScale, stepsForInterval, stepsForRoot } =
       this.keys.notes.currentModeSteps();
-    this.elementKeys
-      .querySelectorAll("[step]")
-      .forEach((a) => a.removeAttribute("step"));
-    stepsForScale.forEach((step) => {
-      const element = this.elementKeys.querySelector(
-        `button:nth-child(${step + 1})`
-      );
-      if (element) {
-        if (stepsForRoot.includes(step)) {
-          element.setAttribute("step", "root");
-        } else if (stepsForInterval.includes(step)) {
-          element.setAttribute("step", "interval");
-        } else {
-          element.setAttribute("step", "scale");
-        }
+    this.keyButtons.forEach((button, step) => {
+      if (!stepsForScale.includes(step)) {
+        button.removeAttribute("step");
+      } else if (stepsForRoot.includes(step)) {
+        button.setAttribute("step", "root");
+      } else if (stepsForInterval.includes(step)) {
+        button.setAttribute("step", "interval");
+      } else {
+        button.setAttribute("step", "scale");
       }
     });
     this.updateKeyboardActives();
@@ -443,45 +440,34 @@ export class Renderer {
 
   updateKeyboardActives() {
     const { mainStep, ghostSteps } = this.keys;
-    this.elementKeys
-      .querySelectorAll("[active]")
-      .forEach((a) => a.removeAttribute("active"));
+    this.keyButtons.forEach((button) => button.removeAttribute("active"));
     if (mainStep !== null) {
-      this.elementKeys
-        .querySelector(`button:nth-child(${mainStep + 1})`)
-        ?.setAttribute("active", "main");
+      this.keyButtons[mainStep]?.setAttribute("active", "main");
       ghostSteps.forEach((ghostStep) => {
-        this.elementKeys
-          .querySelector(`button:nth-child(${ghostStep + 1})`)
-          ?.setAttribute("active", "ghost");
+        this.keyButtons[ghostStep]?.setAttribute("active", "ghost");
       });
     }
   }
 
   updatePads(activeInterval: number) {
-    this.elementPads
-      .querySelectorAll("button:not(:nth-child(8))")
-      .forEach((child) => {
-        child.setAttribute("state", "0");
-        child.removeAttribute("active");
-      });
-    const activePad = this.elementPads.querySelector(
-      `button:nth-child(${activeInterval + 1})`
-    );
+    this.padButtons.forEach((pad, i) => {
+      if (i === 7) return;
+      pad.setAttribute("state", "0");
+      pad.removeAttribute("active");
+    });
+    const activePad = this.padButtons[activeInterval];
     activePad?.setAttribute("state", "4/4");
     activePad?.setAttribute("active", "");
   }
 
   updateStep(
-    element: HTMLDivElement,
+    sequencerKey: string,
     row: number,
     col: number,
     state: StepsSlot,
     stateMax: StepsSlot
   ) {
-    const button = element.querySelector<HTMLButtonElement>(
-      `div:nth-child(${row + 1}) > button:nth-child(${col + 1})`
-    );
+    const button = this.sequencerButtons[sequencerKey]?.[row]?.[col];
     button?.setAttribute("state", state ? `${state}/${stateMax}` : `${state}`);
   }
 
@@ -489,8 +475,7 @@ export class Renderer {
     this.sequencers.forEach((sequencer) =>
       sequencer.steps.rows.forEach((stepRow, row) => {
         stepRow.slots.forEach((step, col) => {
-          const element = this.sequencerElements[sequencer.key];
-          this.updateStep(element, row, col, step, sequencer.steps.max);
+          this.updateStep(sequencer.key, row, col, step, sequencer.steps.max);
         });
       })
     );
@@ -500,11 +485,15 @@ export class Renderer {
     Object.values(this.sequencerElements).forEach(
       (element) => (element.innerHTML = "")
     );
+    this.sequencerButtons = {};
+    this.activeColumns = {};
     let xMax = 0;
     let yMax = 0;
     this.sequencers.forEach((sequencer) => {
       xMax = Math.max(sequencer.steps.size, xMax);
       yMax = Math.max(sequencer.steps.rows.length, yMax);
+      this.sequencerButtons[sequencer.key] = [];
+      this.activeColumns[sequencer.key] = null;
     });
 
     for (let rowIndex = 0; rowIndex < yMax; rowIndex++) {
@@ -516,15 +505,23 @@ export class Renderer {
             ? document.createElement("div")
             : null;
         rows[i] = row;
-        if (row) this.sequencerElements[sequencer.key].appendChild(row);
+        if (row) {
+          this.sequencerElements[sequencer.key].appendChild(row);
+          this.sequencerButtons[sequencer.key][rowIndex] = [];
+        }
       });
 
       for (let colIndex = 0; colIndex < xMax; colIndex++) {
         this.sequencers.forEach((sequencer, i) => {
           if (rows[i] && colIndex < sequencer.steps.size) {
-            rows[i].appendChild(
-              this.createButton("TAP", sequencer.key, rowIndex, colIndex)
+            const button = this.createButton(
+              "TAP",
+              sequencer.key,
+              rowIndex,
+              colIndex
             );
+            rows[i].appendChild(button);
+            this.sequencerButtons[sequencer.key][rowIndex][colIndex] = button;
           }
         });
       }
@@ -533,27 +530,34 @@ export class Renderer {
   }
 
   renderStep(position: number) {
-    this.clearActives();
-    Object.values(this.sequencerElements).forEach((element) => {
-      const index = position % element.childNodes[0].childNodes.length;
-      element
-        .querySelectorAll(`div > button:nth-child(${index + 1})`)
-        .forEach((element) => element.setAttribute("active", "true"));
+    this.sequencers.forEach((sequencer) => {
+      const rows = this.sequencerButtons[sequencer.key];
+      if (!rows || !rows[0] || !rows[0].length) return;
+      const col = position % rows[0].length;
+      const previous = this.activeColumns[sequencer.key];
+      if (previous === col) return;
+      rows.forEach((rowButtons) => {
+        if (previous !== null && previous !== undefined) {
+          rowButtons[previous]?.removeAttribute("active");
+        }
+        rowButtons[col]?.setAttribute("active", "true");
+      });
+      this.activeColumns[sequencer.key] = col;
     });
   }
 
   clearActives() {
-    Object.values(this.sequencerElements).forEach((element) =>
-      element
-        .querySelectorAll(`div > button[active="true"]`)
-        .forEach((element) => element.removeAttribute("active"))
-    );
+    Object.entries(this.sequencerButtons).forEach(([key, rows]) => {
+      rows.forEach((rowButtons) =>
+        rowButtons.forEach((button) => button.removeAttribute("active"))
+      );
+      this.activeColumns[key] = null;
+    });
   }
 
   stop() {
     this.elementMain.removeAttribute("stepping");
-    const togglePad = this.elementPads.querySelector("button:nth-child(8)");
-
+    const togglePad = this.padButtons[7];
     togglePad?.setAttribute("state", "1/4");
     togglePad?.removeAttribute("active");
     this.clearActives();
@@ -561,7 +565,7 @@ export class Renderer {
 
   start() {
     this.elementMain.setAttribute("stepping", "true");
-    const togglePad = this.elementPads.querySelector("button:nth-child(8)");
+    const togglePad = this.padButtons[7];
     togglePad?.setAttribute("state", "4/4");
     togglePad?.setAttribute("active", "");
   }

--- a/machines/modulo/src/Synths.ts
+++ b/machines/modulo/src/Synths.ts
@@ -127,8 +127,6 @@ export class ConfigurableSynth {
   nodeB: Synth;
   panA: Panner;
   panB: Panner;
-  reverb: Freeverb;
-  delay: FeedbackDelay;
   output: Gain;
   playing = false;
 
@@ -144,14 +142,10 @@ export class ConfigurableSynth {
     this.nodeB = new Synth();
     this.panA = new Panner();
     this.panB = new Panner();
-    this.delay = new FeedbackDelay();
-    this.reverb = new Freeverb();
     this.nodeA.connect(this.panA);
     this.nodeB.connect(this.panB);
-    this.panA.connect(this.delay);
-    this.panB.connect(this.delay);
-    this.delay.connect(this.reverb);
-    this.reverb.connect(this.output);
+    this.panA.connect(this.output);
+    this.panB.connect(this.output);
     this.updateSettings(settings);
   }
 
@@ -182,6 +176,9 @@ export class ConfigurableSynth {
     this.stop(getTransport().context.currentTime);
     this.nodeA.dispose();
     this.nodeB.dispose();
+    this.panA.dispose();
+    this.panB.dispose();
+    this.output.dispose();
   }
 
   static randomOptions() {
@@ -217,7 +214,7 @@ export class ConfigurableSynth {
     };
   }
 
-  exportParams(): ConfigurableSynthParams {
+  exportParams(): Pick<ConfigurableSynthParams, "a" | "b"> {
     return {
       a: {
         pan: this.panA.pan.value,
@@ -227,15 +224,6 @@ export class ConfigurableSynth {
         pan: this.panB.pan.value,
         options: this.optionsFromNode(this.nodeB),
       },
-      delay: {
-        wet: this.delay.wet.value,
-        feedback: this.delay.feedback.value,
-        delayTime: this.delay.delayTime.value,
-      },
-      reverb: {
-        wet: this.reverb.wet.value,
-        roomSize: this.reverb.roomSize.value,
-      },
     };
   }
 
@@ -244,8 +232,6 @@ export class ConfigurableSynth {
     this.nodeB.set(settings.b.options);
     this.panA.pan.value = settings.a.pan;
     this.panB.pan.value = settings.b.pan;
-    this.reverb.set(settings.reverb);
-    this.delay.set(settings.delay);
   }
 }
 
@@ -256,6 +242,11 @@ export interface SynthsParams {
 }
 export class Synths {
   output?: Gain;
+  bus?: Gain;
+  delay?: FeedbackDelay;
+  reverb?: Freeverb;
+  delaySettings: SynthSettingsDelay;
+  reverbSettings: SynthSettingsReverb;
   voices: ConfigurableSynth[] = [];
   volume: number;
 
@@ -270,6 +261,8 @@ export class Synths {
     voices: number
   ) {
     this.volume = volume;
+    this.delaySettings = { ...settings.delay };
+    this.reverbSettings = { ...settings.reverb };
     for (let i = 0; i < voices; i++) {
       const synth = new ConfigurableSynth({
         gain: 1 / voices,
@@ -314,43 +307,76 @@ export class Synths {
     this.output = new Gain(this.volume);
     if (mixer.channel) this.output.connect(mixer.channel);
 
+    this.bus = new Gain(1);
     this.voices.forEach((synth) => {
-      if (mixer.channel && this.output) synth.output.connect(this.output);
+      if (this.bus) synth.output.connect(this.bus);
     });
+    this.rewireEffects();
+  }
+
+  // Effects only exist and process audio while their wet amount is non-zero.
+  // Reverbs and delays are expensive on mobile even when silent, so the bus
+  // wires straight through to the output whenever they are inactive.
+  private rewireEffects() {
+    if (!this.bus || !this.output) return;
+    this.bus.disconnect();
+    this.delay?.disconnect();
+    this.reverb?.disconnect();
+    let tail: Gain | FeedbackDelay | Freeverb = this.bus;
+    if (this.delaySettings.wet > 0) {
+      if (!this.delay) this.delay = new FeedbackDelay(this.delaySettings);
+      tail.connect(this.delay);
+      tail = this.delay;
+    }
+    if (this.reverbSettings.wet > 0) {
+      if (!this.reverb) this.reverb = new Freeverb(this.reverbSettings);
+      tail.connect(this.reverb);
+      tail = this.reverb;
+    }
+    tail.connect(this.output);
   }
 
   dispose() {
     this.voices.forEach((synth) => synth.dispose());
+    this.bus?.dispose();
+    this.bus = undefined;
+    this.delay?.dispose();
+    this.delay = undefined;
+    this.reverb?.dispose();
+    this.reverb = undefined;
+    this.output?.dispose();
+    this.output = undefined;
   }
 
   exportParams(): SynthsParams {
     return {
-      volume: this.output?.gain.value || 0,
-      settings: this.voices[0].exportParams(),
+      volume: this.getGain(),
+      settings: {
+        ...this.voices[0].exportParams(),
+        delay: { ...this.delaySettings },
+        reverb: { ...this.reverbSettings },
+      },
       voices: this.voices.length,
     };
   }
 
   getGain() {
-    return this.output?.gain.value || 0;
+    return this.output ? this.output.gain.value : this.volume;
   }
 
   updateDelay(updates: { wet?: number; delayTime?: Time; feedback?: number }) {
-    const delay = this.voices[0].delay;
-    const value = {
-      wet: delay.wet.value,
-      delayTime: delay.delayTime.value,
-      feedback: delay.feedback.value,
-      ...updates,
-    };
-    this.voices.forEach((synth) => {
-      synth.delay.wet.value = value.wet;
-      synth.delay.delayTime.value = value.delayTime;
-      synth.delay.feedback.value = value.feedback;
-    });
+    const wasActive = this.delaySettings.wet > 0;
+    if (updates.wet !== undefined) this.delaySettings.wet = updates.wet;
+    if (updates.feedback !== undefined)
+      this.delaySettings.feedback = updates.feedback;
+    if (updates.delayTime !== undefined)
+      this.delaySettings.delayTime = updates.delayTime;
+    this.delay?.set(this.delaySettings);
+    if (wasActive !== this.delaySettings.wet > 0) this.rewireEffects();
   }
 
   updateGain(gain: number) {
+    this.volume = gain;
     if (this.output) {
       this.output.gain.value = gain;
     }
@@ -364,16 +390,12 @@ export class Synths {
   }
 
   updateReverb(updates: { wet?: number; roomSize?: number }) {
-    const reverb = this.voices[0].reverb;
-    const value = {
-      wet: reverb.wet.value,
-      roomSize: reverb.roomSize.value,
-      ...updates,
-    };
-    this.voices.forEach((synth) => {
-      synth.reverb.wet.value = value.wet;
-      synth.reverb.roomSize.value = value.roomSize;
-    });
+    const wasActive = this.reverbSettings.wet > 0;
+    if (updates.wet !== undefined) this.reverbSettings.wet = updates.wet;
+    if (updates.roomSize !== undefined)
+      this.reverbSettings.roomSize = updates.roomSize;
+    this.reverb?.set(this.reverbSettings);
+    if (wasActive !== this.reverbSettings.wet > 0) this.rewireEffects();
   }
 
   updateSynth(update: SynthSettingsUpdate, a: boolean, b: boolean) {

--- a/machines/modulo/src/destinations/generateDrumsDestinations.ts
+++ b/machines/modulo/src/destinations/generateDrumsDestinations.ts
@@ -138,20 +138,23 @@ function synthEffectsProperties(
           type: "range",
           min: 0,
           max: 1,
-          initialValue: () => numericAsString(loader().delay.feedback.value),
+          initialValue: () =>
+            numericAsString(loader().exportParams().settings.delay.feedback),
         },
         {
           label: "wet",
           type: "range",
           min: 0,
           max: 1,
-          initialValue: () => numericAsString(loader().delay.wet.value),
+          initialValue: () =>
+            numericAsString(loader().exportParams().settings.delay.wet),
         },
         {
           label: "time",
           type: "select",
           options: timeOptions,
-          initialValue: () => Time(loader().delay.delayTime.value).toNotation(),
+          initialValue: () =>
+            Time(loader().exportParams().settings.delay.delayTime).toNotation(),
         },
       ],
       onSet: (_command, [feedback, wet, time]) => {

--- a/machines/modulo/src/destinations/generateSynthsDestinations.ts
+++ b/machines/modulo/src/destinations/generateSynthsDestinations.ts
@@ -198,22 +198,21 @@ export function generateSynthsDestinations({
                   min: 0,
                   max: 1,
                   initialValue: () =>
-                    numericAsString(synth.voices[0].delay.feedback.value),
+                    numericAsString(synth.delaySettings.feedback),
                 },
                 {
                   label: "wet",
                   type: "range",
                   min: 0,
                   max: 1,
-                  initialValue: () =>
-                    numericAsString(synth.voices[0].delay.wet.value),
+                  initialValue: () => numericAsString(synth.delaySettings.wet),
                 },
                 {
                   label: "time",
                   type: "select",
                   options: timeOptions,
                   initialValue: () =>
-                    Time(synth.voices[0].delay.delayTime.value).toNotation(),
+                    Time(synth.delaySettings.delayTime).toNotation(),
                 },
               ],
               onSet: (_command, [feedback, wet, time]) => {
@@ -235,15 +234,14 @@ export function generateSynthsDestinations({
                   min: 0,
                   max: 1,
                   initialValue: () =>
-                    numericAsString(synth.voices[0].reverb.roomSize.value),
+                    numericAsString(synth.reverbSettings.roomSize),
                 },
                 {
                   label: "wet",
                   type: "range",
                   min: 0,
                   max: 1,
-                  initialValue: () =>
-                    numericAsString(synth.voices[0].reverb.wet.value),
+                  initialValue: () => numericAsString(synth.reverbSettings.wet),
                 },
               ],
               onSet: (_command, [size, wet]) => {

--- a/machines/modulo/src/style/base.css
+++ b/machines/modulo/src/style/base.css
@@ -6,6 +6,22 @@ body {
   margin: 0;
 }
 
+/* Rainbow mode: a filter animation runs on the compositor, unlike the old
+   per-frame hue custom-property update which recalculated styles for every
+   oklch() color on the page. */
+html.rainbow body {
+  animation: rainbow-hue-rotation 6s linear infinite;
+}
+
+@keyframes rainbow-hue-rotation {
+  from {
+    filter: hue-rotate(0deg);
+  }
+  to {
+    filter: hue-rotate(360deg);
+  }
+}
+
 prompt-interface {
   padding: var(--padding-y) var(--padding-x) 0;
   width: 100%;

--- a/machines/modulo/src/style/pads.css
+++ b/machines/modulo/src/style/pads.css
@@ -54,7 +54,9 @@ main[stepping="true"] .sequencer {
   border-radius: var(--border-radius);
   box-shadow: var(--box-shadow);
   position: relative;
-  transition: all 80ms ease-in;
+  /* Only transition color — `all` animated box-shadow/opacity on every step
+     tick, forcing continuous repaints on mobile GPUs. */
+  transition: background-color 80ms ease-in;
 
   &.cursor {
     &::after {

--- a/machines/modulo/src/style/reset.css
+++ b/machines/modulo/src/style/reset.css
@@ -6,3 +6,18 @@ button {
 button {
   box-sizing: border-box;
 }
+
+/* Mobile touch: without touch-action the browser waits on double-tap-zoom
+   detection before dispatching clicks, and long-presses trigger text
+   selection / callouts — both make rapid step-tapping feel unresponsive. */
+body,
+button {
+  touch-action: manipulation;
+}
+
+button {
+  -webkit-tap-highlight-color: transparent;
+  -webkit-touch-callout: none;
+  -webkit-user-select: none;
+  user-select: none;
+}


### PR DESCRIPTION
## What

Modulo would become sluggish and eventually hang on mobile. This PR addresses the compounding causes across the audio graph, disposal, rendering, and touch handling. No behavior changes for saved patches — the params JSON shape is unchanged and localStorage/stega round-trips were verified.

## Why / How

### Audio engine
- **Effects were per-voice and always-on.** The default patch ran 8 Freeverbs (≈96 filter nodes) + 8 FeedbackDelays for the synths and 4 BitCrusher audio worklets for the drums — all processing constantly even at `wet: 0`. Web Audio doesn't stop processing connected nodes just because they're silent, and on phones this constant DSP load starves the audio thread and triggers thermal throttling. Delay/reverb now live at the `Synths` group level, and effects (including drum crush/delay) are **created lazily and wired into the chain only while `wet > 0`** via `rewireEffects()`. The default patch idles with zero effect DSP.
- **`dispose()` leaked most of the graph** (panners, delays, reverbs, filters, crushers, output gains), so every patch load accumulated orphaned nodes — progressive degradation. Everything is disposed now. The three drum classes' identical effect plumbing is consolidated into a `ConfigurableDrum` base class.
- **Step visuals ran inside the Transport tick callback**, ~100ms ahead of the audible beat and competing with note scheduling. They now go through `Tone.getDraw().schedule(...)`, which also pauses visual work in hidden tabs.
- Fixed a latent bug: `Drums.updateSettings` indexed the kit *array* with a string type (`kit["open"]` → undefined); it now finds by type.

### Rendering
- Step/key/pad buttons are cached in arrays when the grid is built; the per-tick `renderStep` and all update paths no longer run `querySelectorAll` with `nth-child` selectors, and only the previously active column is cleared per tick.
- `transition: all` animated box-shadows/opacity on ~150 buttons on every step advance (continuous repaint); now only `background-color` transitions.
- Rainbow mode is a CSS `hue-rotate` keyframe animation on a class toggle (compositor-only) instead of a per-frame custom-property write on `<html>` that forced a full-document style recalc through every `oklch(calc(...))` color — and the rAF loop ran even when the feature was off.
- Theme stylesheet is built in one write instead of `innerHTML +=` per color; `theme-key-*` classes no longer accumulate on the keys/pads elements.

### Mobile touch
- `touch-action: manipulation` + `user-select: none` (+ tap-highlight/callout suppression) on buttons, so taps dispatch immediately instead of waiting on double-tap-zoom detection and long-presses don't trigger selection. `click` handlers are kept (rather than `pointerdown`) because the MIDI cursor's `handleCursorSelect` relies on `button.click()`.

## Reviewer notes

- The prompt UI's effects forms now read initial values from stored params (`delaySettings`/`reverbSettings`, drum `exportParams()`) instead of live node properties, since nodes may not exist at `wet: 0`.
- Exported `delayTime` is now the stored notation (e.g. `"16n"`) rather than the node's resolved seconds — both are valid Tone `Time` values and load identically.
- Turning a wet knob from 0 to >0 inserts the effect into the chain; there may be a one-time click on insertion, which seemed acceptable vs. the constant idle cost.
- Verified in-browser: boot from defaults and from localStorage, step toggling/cycling, play/stop active-column rendering, keyboard scale/active attributes, prompt navigation to `lead/effects` with delay wet 0 → 0.4 → 0 (lazy create + unwire), rainbow toggle, and a production `parcel build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)