### PR TITLE
Store modulo settings images as a Stegassette text/json entry

### DIFF
--- a/machines/modulo/src/Machine.ts
+++ b/machines/modulo/src/Machine.ts
@@ -24,11 +24,13 @@ import { Steps } from "./Steps";
 import { Synths } from "./Synths";
 import { MIDI, type MIDIEvent } from "../../../packages/amplib-devices/src";
 import {
-  Stega64,
-  StegaMetadata,
+  Stegassette,
   createDropReader,
 } from "../../../packages/amplib-steganography/src";
 import register from "./prompt/register";
+
+const SETTINGS_MIMETYPE = "text/json";
+const SETTINGS_NAME = "modulo.json";
 
 export interface MachineCore {
   theme: number;
@@ -218,26 +220,22 @@ export class Machine {
 
   loadSettingsFromImage(image: HTMLImageElement): boolean {
     try {
-      const metadata = StegaMetadata.decode({ source: image });
-      if (
-        !metadata ||
-        metadata.type === StegaMetadata.StegaContentType.STRING
-      ) {
-        const [decoded] = Stega64.decode({
-          source: image,
-          encoding: metadata?.encoding || "base64",
-          borderWidth: metadata?.borderWidth,
-        });
-        const settings = JSON.parse(decoded || "") as MachineParams;
-        this.update(settings);
-        // Save the loaded settings to localStorage
-        this.saveToLocalStorage();
-        return true;
-      }
+      const { entries } = Stegassette.decode({ source: image });
+      const entry =
+        entries.find((item) => item.mimetype === SETTINGS_MIMETYPE) ||
+        entries[0];
+      if (!entry) return false;
+      const settings = JSON.parse(
+        new TextDecoder().decode(entry.data)
+      ) as MachineParams;
+      this.update(settings);
+      // Save the loaded settings to localStorage
+      this.saveToLocalStorage();
+      return true;
     } catch (e) {
       console.log(e);
+      return false;
     }
-    return false;
   }
 
   // File-picker path for loading a settings image — on mobile this opens the
@@ -347,11 +345,15 @@ export class Machine {
   onExport(type: "image" | "json" | "url") {
     if (type === "image") {
       this.promptInterface.toggle();
-      const canvas = Stega64.encode({
+      const canvas = Stegassette.encode({
         source: this.renderer.snapshot(),
-        messages: [JSON.stringify(this.exportParams())],
-        encoding: "base64",
-        encodeMetadata: true,
+        entries: [
+          {
+            mimetype: SETTINGS_MIMETYPE,
+            name: SETTINGS_NAME,
+            data: JSON.stringify(this.exportParams()),
+          },
+        ],
       });
       // An <img> rather than the canvas itself: mobile browsers only offer
       // "Save to Photos" on long-press for images.


### PR DESCRIPTION
## What

Settings images exported by modulo used `Stega64` with a separate `StegaMetadata` header. They now use the Stegassette container with a single `text/json` entry named `modulo.json`.

## Why

The old format stored the params as an opaque string whose encoding had to be recovered from a metadata header before it could be read. The Stegassette container carries the mimetype and name with the payload, so an exported image is self-describing — a decoder can see it holds JSON without being told.

## Changes

`save/image` encodes one entry:

```ts
Stegassette.encode({
  source: this.renderer.snapshot(),
  entries: [{ mimetype: "text/json", name: "modulo.json", data: JSON.stringify(this.exportParams()) }],
})
```

Loading reads that entry back out and parses it. Both the drag-and-drop reader and the mobile photo picker share the path, so neither changes.

There is no fallback to the old format — `Stega64` and `StegaMetadata` are no longer imported by the machine. Images exported before this change will not load.

Removing the Stega64 path also removes the last two type errors in the machine; they were in the metadata narrowing that path required, so `tsc` is now clean for modulo.

## Testing

Round-tripped in the running app: exported an image at tempo 94, changed the tempo to 99, loaded the exported PNG back through the file-picker path, and the machine returned to 94. Production build passes, and dropping Stega64 takes the bundle from 380 kB to 371 kB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)