### PR TITLE
Fix the pale strip on exported settings images

### DIFF
--- a/machines/modulo/src/Renderer.ts
+++ b/machines/modulo/src/Renderer.ts
@@ -390,6 +390,10 @@ export class Renderer {
     let maxX = -Infinity;
     let maxY = -Infinity;
     this.elementMain.querySelectorAll("button").forEach((button) => {
+      // The editor toggle is chrome rather than part of the instrument's
+      // face — including it painted a pale full-width bar along the bottom
+      // and stretched the captured bounds to match.
+      if (button === this.elementEditorToggle) return;
       const { top, right, bottom, left } = button.getBoundingClientRect();
       minX = Math.min(minX, left);
       minY = Math.min(minY, top);
@@ -408,7 +412,9 @@ export class Renderer {
     canvas.width = width + padding * 2;
     canvas.height = height + padding * 2;
     context.fillStyle = background;
-    context.fillRect(0, 0, width, height);
+    // The whole canvas, not just the button bounds — the padding ring was
+    // left transparent, which flattens to white wherever the export lands.
+    context.fillRect(0, 0, canvas.width, canvas.height);
 
     buttons.forEach(({ top, right, bottom, left, fill }) => {
       context.fillStyle = fill;

--- a/packages/amplib-steganography/src/Stegassette/browser.ts
+++ b/packages/amplib-steganography/src/Stegassette/browser.ts
@@ -18,7 +18,7 @@ import { containerInteriorBytes, entryTableSize } from "./entries";
 import { packStgcHeader } from "./header";
 import type { CombineName, DecodedEntry, EncodeOptions, KeymapName, StegaImageData, StgcOpts, TraversalParams } from "./types";
 
-function estimatedHeaderLength(
+function estimatedHeaderPixels(
   opts: Partial<EncodeOptions>,
   plan: ReturnType<typeof normalizeChannelPlan>,
   params: TraversalParams,
@@ -39,6 +39,11 @@ function estimatedHeaderLength(
     // nibble pairs: two border pixels per header byte, plus the ring-start
     // B bootstrap and even-offset alignment
   }).length * 2 + 8;
+}
+
+/** Border-ring pixel count, clamped for borders thicker than the image. */
+function ringPixelCount(W: number, H: number, B: number): number {
+  return W * H - Math.max(0, W - 2 * B) * Math.max(0, H - 2 * B);
 }
 
 // Re-export the entire pure core so `import * as Stegassette from "./browser"`
@@ -117,7 +122,7 @@ export function encode({
   const aspect = aspectRatio ?? src.width / src.height;
   const totalBytes = containerInteriorBytes(entries) + plan.pad;
   const dataPx = Math.ceil(totalBytes / plan.bytesPerPixel);
-  const B = resolveBorderWidth(border, dataPx, aspect);
+  let B = resolveBorderWidth(border, dataPx, aspect);
 
   const params: TraversalParams = {
     ...(opts.params || {}),
@@ -127,16 +132,28 @@ export function encode({
     ...(opts.kx != null ? { kx: opts.kx } : {}),
     ...(opts.ky != null ? { ky: opts.ky } : {}),
   };
-  const minFullWidth = estimatedHeaderLength(opts, plan, params, entries.length);
+  const headerPx = estimatedHeaderPixels(opts, plan, params, entries.length);
 
-  const scaled = autoScaleImg(
+  // The canvas is sized by the payload alone; when the border ring cannot
+  // hold the header, thicken the border instead of growing the image.
+  let scaled = autoScaleImg(
     src,
     totalBytes,
     B,
     aspectRatio ?? null,
-    plan.bytesPerPixel,
-    minFullWidth
+    plan.bytesPerPixel
   );
+  while (ringPixelCount(scaled.width, scaled.height, B) < headerPx) {
+    if (B > 255) throw new Error("STGC header does not fit any border");
+    B += 1;
+    scaled = autoScaleImg(
+      src,
+      totalBytes,
+      B,
+      aspectRatio ?? null,
+      plan.bytesPerPixel
+    );
+  }
 
   const outImg = encodeContainer(
     entries,

--- a/packages/amplib-steganography/src/Stegassette/browser.ts
+++ b/packages/amplib-steganography/src/Stegassette/browser.ts
@@ -36,7 +36,9 @@ function estimatedHeaderLength(
       : serializeChannelPlan(plan.slots),
     pad: plan.pad,
     pack: plan.pack,
-  }).length;
+    // nibble pairs: two border pixels per header byte, plus the ring-start
+    // B bootstrap and even-offset alignment
+  }).length * 2 + 8;
 }
 
 // Re-export the entire pure core so `import * as Stegassette from "./browser"`

--- a/packages/amplib-steganography/src/Stegassette/container.ts
+++ b/packages/amplib-steganography/src/Stegassette/container.ts
@@ -192,9 +192,16 @@ export function encodeContainer(
     pack: plan.pack,
   });
 
-  if (hdrBytes.length > srcImg.width)
+  // The header flows along the border ring (two pixels per byte), so the
+  // constraint is ring capacity rather than image width.
+  const ringPx =
+    srcImg.width * srcImg.height -
+    Math.max(0, srcImg.width - 2 * B) * Math.max(0, srcImg.height - 2 * B);
+  if (hdrBytes.length * 2 + 6 > ringPx)
     throw new Error(
-      `image too narrow for STGC header (need ${hdrBytes.length}px, width is ${srcImg.width})`
+      `border ring too small for STGC header (need ${
+        hdrBytes.length * 2 + 6
+      }px, ring is ${ringPx})`
     );
 
   writeInterior(outImg, key, stream, { borderWidth: B, combine, keymap, traversal, params, plan });

--- a/packages/amplib-steganography/src/Stegassette/header.ts
+++ b/packages/amplib-steganography/src/Stegassette/header.ts
@@ -130,27 +130,87 @@ export interface ParsedHeader extends StgcOpts {
 }
 
 /**
+ * Header bytes ride the border alpha as high/low nibble pairs, so every
+ * header pixel keeps alpha ≥ 240 and the border renders as good as opaque.
+ * A nibble n is stored as alpha 255 - n; an untouched border pixel (255)
+ * reads back as nibble 0.
+ */
+function nibbleByte(alphaHi: number, alphaLo: number): number {
+  return (((255 - alphaHi) & 0xf) << 4) | ((255 - alphaLo) & 0xf);
+}
+
+/**
  * Read the STGC header from the border alpha channel of an image.
  *
- * alpha(0,0) = B low byte; 0 = sentinel meaning 2-byte B follows in bpx[1] and bpx[2].
- * The header bytes are located by scanning for the STGC magic in border alpha values.
+ * Current images store nibble pairs (see `nibbleByte`); before that the
+ * format stored one raw byte per pixel — which rendered the header as a
+ * nearly transparent strip — so all three layouts are tried in turn:
+ * nibble pairs, then whole bytes inverted, then whole bytes raw.
+ *
+ * byte 0 of the ring = B low byte; 0 = sentinel meaning a 2-byte B follows.
+ * The header is located by scanning the ring bytes for the STGC magic.
  */
 export function unpackStgcHeaderAlpha(img: Img): ParsedHeader {
-  let B = img.getAlpha(0, 0);
+  try {
+    return unpackNibbles(img);
+  } catch (e) {
+    try {
+      return unpackWholeBytes(img, (alpha) => 255 - alpha);
+    } catch (e2) {
+      return unpackWholeBytes(img, (alpha) => alpha);
+    }
+  }
+}
+
+function unpackNibbles(img: Img): ParsedHeader {
+  // bootstrap B from the ring start — raster order makes the first pixels
+  // identical for every border width
+  const tmpBpx = getBorderPixels(img.width, img.height, 1);
+  if (tmpBpx.length < 6) throw new Error("not a STGC image");
+  const alphaAt = (i: number) =>
+    img.getAlpha(tmpBpx[i][0], tmpBpx[i][1]);
+  let B = nibbleByte(alphaAt(0), alphaAt(1));
+  if (B === 0) {
+    B =
+      nibbleByte(alphaAt(2), alphaAt(3)) |
+      (nibbleByte(alphaAt(4), alphaAt(5)) << 8);
+    if (B === 0) throw new Error("not a STGC image");
+  }
+
+  const bpx = getBorderPixels(img.width, img.height, B);
+  const bytes = new Uint8Array(bpx.length >> 1);
+  for (let i = 0; i < bytes.length; i++)
+    bytes[i] = nibbleByte(
+      img.getAlpha(bpx[i * 2][0], bpx[i * 2][1]),
+      img.getAlpha(bpx[i * 2 + 1][0], bpx[i * 2 + 1][1])
+    );
+  return parseRingBytes(bytes, B);
+}
+
+function unpackWholeBytes(
+  img: Img,
+  read: (alpha: number) => number
+): ParsedHeader {
+  let B = read(img.getAlpha(0, 0));
   if (B === 0) {
     // 2-byte B: enumerate with B=1 to find bpx[1] and bpx[2]
     const tmpBpx = getBorderPixels(img.width, img.height, 1);
     if (tmpBpx.length < 3) throw new Error("not a STGC image");
     B =
-      img.getAlpha(tmpBpx[1][0], tmpBpx[1][1]) |
-      (img.getAlpha(tmpBpx[2][0], tmpBpx[2][1]) << 8);
+      read(img.getAlpha(tmpBpx[1][0], tmpBpx[1][1])) |
+      (read(img.getAlpha(tmpBpx[2][0], tmpBpx[2][1])) << 8);
     if (B === 0) throw new Error("not a STGC image");
   }
 
   const bpx = getBorderPixels(img.width, img.height, B);
   const alphas = new Uint8Array(bpx.length);
   for (let i = 0; i < bpx.length; i++)
-    alphas[i] = img.getAlpha(bpx[i][0], bpx[i][1]);
+    alphas[i] = read(img.getAlpha(bpx[i][0], bpx[i][1]));
+  return parseRingBytes(alphas, B);
+}
+
+function parseRingBytes(alphas: Uint8Array, B: number): ParsedHeader {
+  const bpx = { length: alphas.length };
 
   // scan for the STGC magic in the alpha sequence
   let magicOff = -1;
@@ -245,15 +305,25 @@ export function applyAlphaHeader(
   offset?: number
 ): void {
   const bpx = getBorderPixels(outImg.width, outImg.height, B);
+  // Each byte rides two pixels as high/low nibbles (alpha = 255 - nibble),
+  // keeping every header pixel at alpha ≥ 240 — raw bytes per pixel rendered
+  // the header as a nearly transparent strip along the border. A zero byte
+  // lands on alpha 255 exactly, so no zero-clamping or checksum recovery is
+  // needed on this layout.
+  const putByte = (index: number, byte: number) => {
+    outImg.setAlpha(bpx[index][0], bpx[index][1], 255 - ((byte >> 4) & 0xf));
+    outImg.setAlpha(bpx[index + 1][0], bpx[index + 1][1], 255 - (byte & 0xf));
+  };
+
   let minOffset: number;
   if (B > 255) {
-    outImg.setAlpha(0, 0, 0); // sentinel
-    outImg.setAlpha(bpx[1][0], bpx[1][1], B & 0xff);
-    outImg.setAlpha(bpx[2][0], bpx[2][1], (B >> 8) & 0xff);
-    minOffset = 3;
+    putByte(0, 0); // sentinel
+    putByte(2, B & 0xff);
+    putByte(4, (B >> 8) & 0xff);
+    minOffset = 6;
   } else {
-    outImg.setAlpha(0, 0, B);
-    minOffset = 1;
+    putByte(0, B);
+    minOffset = 2;
   }
 
   if (offset == null) {
@@ -261,13 +331,13 @@ export function applyAlphaHeader(
     const H = outImg.height;
     const bottomStart = bpx.findIndex(([, py]) => py === H - 1);
     const bottomLen = outImg.width;
-    offset = bottomStart + ((bottomLen - hdrBytes.length) >> 1);
+    offset = bottomStart + ((bottomLen - hdrBytes.length * 2) >> 1);
   }
-  offset = Math.max(minOffset, offset);
+  // even ring index, so decode can pair pixels deterministically from 0
+  offset = Math.max(minOffset, offset) & ~1;
 
   for (let i = 0; i < hdrBytes.length; i++) {
-    const b = hdrBytes[i];
-    outImg.setAlpha(bpx[offset + i][0], bpx[offset + i][1], b === 0 ? 1 : b);
+    putByte(offset + i * 2, hdrBytes[i]);
   }
 }
 

--- a/packages/amplib-steganography/src/Stegassette/header.ts
+++ b/packages/amplib-steganography/src/Stegassette/header.ts
@@ -326,13 +326,21 @@ export function applyAlphaHeader(
     minOffset = 2;
   }
 
+  const headerPx = hdrBytes.length * 2;
+  if (minOffset + headerPx > bpx.length)
+    throw new Error("STGC header does not fit the border ring");
+
   if (offset == null) {
     // centre in bottom row: find first bottom-row pixel in border sequence
     const H = outImg.height;
     const bottomStart = bpx.findIndex(([, py]) => py === H - 1);
     const bottomLen = outImg.width;
-    offset = bottomStart + ((bottomLen - hdrBytes.length * 2) >> 1);
+    offset = bottomStart + ((bottomLen - headerPx) >> 1);
   }
+  // The ring is contiguous in index space and decode scans all of it, so a
+  // header that cannot centre in the bottom row simply starts earlier and
+  // flows across the other border pixels.
+  offset = Math.min(offset, bpx.length - headerPx);
   // even ring index, so decode can pair pixels deterministically from 0
   offset = Math.max(minOffset, offset) & ~1;
 

--- a/packages/amplib-steganography/src/Stegassette/index.ts
+++ b/packages/amplib-steganography/src/Stegassette/index.ts
@@ -125,7 +125,7 @@ import type { CombineName, DecodedEntry, EncodeOptions, KeymapName, StegaImageDa
  * Estimate the STGC header byte length for the given encode options.
  * Used to enforce a minimum canvas width so the header always fits.
  */
-function estimatedHeaderLength(
+function estimatedHeaderPixels(
   opts: Partial<EncodeOptions>,
   plan: ReturnType<typeof normalizeChannelPlan>,
   params: TraversalParams,
@@ -146,6 +146,11 @@ function estimatedHeaderLength(
     // nibble pairs: two border pixels per header byte, plus the ring-start
     // B bootstrap and even-offset alignment
   }).length * 2 + 8;
+}
+
+/** Border-ring pixel count, clamped for borders thicker than the image. */
+function ringPixelCount(W: number, H: number, B: number): number {
+  return W * H - Math.max(0, W - 2 * B) * Math.max(0, H - 2 * B);
 }
 
 export interface EncodeImageDataOptions extends EncodeOptions {
@@ -182,7 +187,7 @@ export function encodeImageData({
   const aspect = aspectRatio ?? src.width / src.height;
   const totalBytes = containerInteriorBytes(entries) + plan.pad;
   const dataPx = Math.ceil(totalBytes / plan.bytesPerPixel);
-  const B = resolveBorderWidth(border, dataPx, aspect);
+  let B = resolveBorderWidth(border, dataPx, aspect);
 
   // Merge traversal/keymap params for header-length estimation
   const params: TraversalParams = {
@@ -193,9 +198,16 @@ export function encodeImageData({
     ...(opts.kx != null ? { kx: opts.kx } : {}),
     ...(opts.ky != null ? { ky: opts.ky } : {}),
   };
-  const minFullWidth = estimatedHeaderLength(opts, plan, params, entries.length);
+  const headerPx = estimatedHeaderPixels(opts, plan, params, entries.length);
 
-  const scaled = autoScaleImg(src, totalBytes, B, aspectRatio ?? null, plan.bytesPerPixel, minFullWidth);
+  // The canvas is sized by the payload alone; when the border ring cannot
+  // hold the header, thicken the border instead of growing the image.
+  let scaled = autoScaleImg(src, totalBytes, B, aspectRatio ?? null, plan.bytesPerPixel);
+  while (ringPixelCount(scaled.width, scaled.height, B) < headerPx) {
+    if (B > 255) throw new Error("STGC header does not fit any border");
+    B += 1;
+    scaled = autoScaleImg(src, totalBytes, B, aspectRatio ?? null, plan.bytesPerPixel);
+  }
 
   return encodeContainer(entries, scaled, { ...opts, borderWidth: B, plan }, scaled);
 }

--- a/packages/amplib-steganography/src/Stegassette/index.ts
+++ b/packages/amplib-steganography/src/Stegassette/index.ts
@@ -143,7 +143,9 @@ function estimatedHeaderLength(
       : serializeChannelPlan(plan.slots),
     pad: plan.pad,
     pack: plan.pack,
-  }).length;
+    // nibble pairs: two border pixels per header byte, plus the ring-start
+    // B bootstrap and even-offset alignment
+  }).length * 2 + 8;
 }
 
 export interface EncodeImageDataOptions extends EncodeOptions {


### PR DESCRIPTION
## What

Exported settings images showed a small pale strip along the bottom when viewed on a light background. Three causes, from the machine's snapshot up into the Stegassette format itself.

## Causes and fixes

**The snapshot painted the editor toggle.** The bar under the keyboard is a button inside `main`, so the export's cover image gained a full-width bar along the bottom and stretched bounds to hold it. It's chrome, not part of the instrument's face — skipped now.

**The snapshot left its padding ring transparent.** The background fill covered only the button bounds, not the full canvas, so the padding ring flattened to white on any light surface. The fill now covers the whole canvas.

**The STGC header itself rendered as a near-transparent strip.** The format wrote one raw header byte per border pixel's *alpha*. Header bytes are mostly small — ASCII descriptor text, length fields — so the header, deliberately centred in the bottom border row, sat at alpha ~1–120: a pale band on any light backdrop, on every Stegassette image, regardless of the cover.

The header now rides two pixels per byte as high/low nibbles, stored as `255 − nibble`, so every header pixel keeps **alpha ≥ 240** and the border is visually opaque (worst-case bleed ≈ 6% on isolated pixels). Zero bytes land on alpha 255 exactly, so this layout needs no zero-clamping or checksum recovery. The B bootstrap at the ring start uses the same pairs, header offsets are forced even so decode can pair pixels deterministically, and width estimates account for the doubled footprint.

**Backward compatible:** `unpackStgcHeaderAlpha` tries nibble pairs first, then falls back to whole bytes (inverted, then raw), so images encoded before this change still decode.

## Testing

- Encoded a probe image with the pre-change code, then decoded it with the new code — passes via the fallback path.
- Fresh node round trip through `encodeImageData`/`decodeImageData` — passes; border alpha min goes **1 → 240**, zero pixels below 240.
- Full modulo flow: export at tempo 90 → mutate to 95 → load the exported PNG back through the file picker → returns to 90. The exported PNG measures min alpha 240.
- Visual check of the export on a pure white backdrop: no strip, solid dark border.
- No new type errors (`StegaCassette`'s pre-existing `Float32Array` complaints are untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)