### PR TITLE
Modulo channel solo/mute rail + stegassette edge-corruption fixes

### DIFF
--- a/machines/modulo/src/Drums.ts
+++ b/machines/modulo/src/Drums.ts
@@ -344,6 +344,9 @@ export class Drums {
   output?: Gain;
   kit: (ConfigurableHat | ConfigurableSnare | ConfigurableKick)[] = [];
   volume: number;
+  // Mute lives outside `volume` so exports and the volume UI keep reporting
+  // the channel's set level while the output is silenced.
+  muted = false;
 
   static velocitiesForStepsSlots(
     stepsSlotArray: StepsSlot[],
@@ -371,7 +374,7 @@ export class Drums {
   }
 
   initialize({ mixer }: { mixer: Mixer }) {
-    this.output = new Gain(this.volume);
+    this.output = new Gain(this.muted ? 0 : this.volume);
     if (mixer.channel) this.output.connect(mixer.channel);
 
     this.kit.forEach((drum) => {
@@ -392,7 +395,7 @@ export class Drums {
   exportParams(): DrumsParams {
     const settings = this.kit.map((a) => a.exportParams());
     return {
-      volume: this.output ? this.output.gain.value : this.volume,
+      volume: this.volume,
       settings,
     };
   }
@@ -404,13 +407,20 @@ export class Drums {
   }
 
   getGain() {
-    return this.output ? this.output.gain.value : this.volume;
+    return this.volume;
+  }
+
+  setMuted(muted: boolean) {
+    this.muted = muted;
+    if (this.output) {
+      this.output.gain.value = muted ? 0 : this.volume;
+    }
   }
 
   updateGain(gain: number) {
     this.volume = gain;
     if (this.output) {
-      this.output.gain.value = gain;
+      this.output.gain.value = this.muted ? 0 : gain;
     }
   }
 }

--- a/machines/modulo/src/Keyboard.ts
+++ b/machines/modulo/src/Keyboard.ts
@@ -60,6 +60,11 @@ export class Keyboard {
     this.ghosts.dispose();
   }
 
+  setMuted(muted: boolean) {
+    this.main.setMuted(muted);
+    this.ghosts.setMuted(muted);
+  }
+
   exportParams(): KeyboardParams {
     return {
       theme: this.theme,

--- a/machines/modulo/src/Machine.ts
+++ b/machines/modulo/src/Machine.ts
@@ -59,6 +59,10 @@ export class Machine {
   promptInterface!: PromptInterface;
   renderer!: Renderer;
   sequencers!: Sequencer[];
+  // Session-only mixer state — muting a channel shouldn't change what an
+  // export or save reports for its volume.
+  channelMutes = new Set<string>();
+  channelSolos = new Set<string>();
   private saveTimeout?: number;
 
   constructor(initialParams: MachineParams & { element: HTMLElement }) {
@@ -190,6 +194,31 @@ export class Machine {
     if (!firstPass && this.initialized) {
       this.debouncedSaveToLocalStorage();
     }
+
+    // Audio nodes and rail buttons were just rebuilt; re-silence whatever
+    // was muted or un-soloed before the update.
+    if (!firstPass) {
+      this.applyChannelStates();
+    }
+  }
+
+  get channelKeys(): string[] {
+    return [...this.sequencers.map((sequencer) => sequencer.key), "keys"];
+  }
+
+  applyChannelStates() {
+    const solos = this.channelSolos;
+    const states = this.channelKeys.map((key) => {
+      const muted = this.channelMutes.has(key);
+      const audible = !muted && (solos.size === 0 || solos.has(key));
+      const target =
+        key === "keys"
+          ? this.keys
+          : this.sequencers.find((sequencer) => sequencer.key === key);
+      target?.setMuted(!audible);
+      return { key, muted, soloed: solos.has(key), audible };
+    });
+    this.renderer.updateChannelStates(states);
   }
 
   setup() {
@@ -464,6 +493,19 @@ export class Machine {
   ) {
     if (type === "TAP" && location === "EDITOR") {
       this.promptInterface.toggle();
+      return;
+    }
+    if (type === "TAP" && (location === "SOLO" || location === "MUTE")) {
+      const key = this.channelKeys[valueA];
+      if (key) {
+        const set = location === "SOLO" ? this.channelSolos : this.channelMutes;
+        if (set.has(key)) {
+          set.delete(key);
+        } else {
+          set.add(key);
+        }
+        this.applyChannelStates();
+      }
       return;
     }
     if (type === "TAP" && location === "PADS") {

--- a/machines/modulo/src/Renderer.ts
+++ b/machines/modulo/src/Renderer.ts
@@ -3,7 +3,14 @@ import { MachineCore } from "./Machine";
 import { Sequencer } from "./Sequencer";
 import { StepsSlot } from "./Steps";
 export type RendererEventType = "TAP" | "PRESS" | "RELEASE";
-export type RendererEventLocation = "KEYS" | "PADS" | string;
+export type RendererEventLocation = "KEYS" | "PADS" | "SOLO" | "MUTE" | string;
+
+export interface RendererChannelState {
+  key: string;
+  muted: boolean;
+  soloed: boolean;
+  audible: boolean;
+}
 export type RendererEventHandler = (
   eventType: RendererEventType,
   eventLocation: RendererEventLocation,
@@ -51,6 +58,15 @@ export class Renderer {
   keyButtons: HTMLButtonElement[] = [];
   padButtons: HTMLButtonElement[] = [];
   elementEditorToggle = document.createElement("button");
+  channelRails: {
+    [key: string]: {
+      element: HTMLDivElement;
+      solo: HTMLButtonElement;
+      mute: HTMLButtonElement;
+    };
+  } = {};
+  channelWrappers: { [key: string]: HTMLDivElement } = {};
+  padsRail: HTMLDivElement | null = null;
   sequencers: Sequencer[] = [];
   keys: Keyboard;
   elementKeys = document.createElement("div");
@@ -83,13 +99,12 @@ export class Renderer {
     this.keys = keys;
     this.setTheme(theme);
     this.rendererEventHandler = rendererEventHandler;
+    this.initializeEditorToggle();
     this.initializeSequencers();
-    this.elementMain.appendChild(this.elementPads);
-    this.elementMain.appendChild(this.elementKeys);
-    this.elementMain.appendChild(this.elementEditorToggle);
+    this.attachPadsChannel();
+    this.attachKeysChannel();
     this.initializePads();
     this.initializeKeys();
-    this.initializeEditorToggle();
   }
 
   initializeEditorToggle() {
@@ -98,6 +113,58 @@ export class Renderer {
     this.elementEditorToggle.addEventListener("click", () =>
       this.rendererEventHandler("TAP", "EDITOR", 0)
     );
+  }
+
+  // Every row owns a slot on the right rail: sequencers and keys get a
+  // stacked solo/mute pair, the pads row gets the editor toggle.
+  private createChannelWrapper(key: string, section: HTMLElement) {
+    const wrapper = document.createElement("div");
+    wrapper.className = "channel";
+    wrapper.appendChild(section);
+    this.elementMain.appendChild(wrapper);
+    this.channelWrappers[key] = wrapper;
+    return wrapper;
+  }
+
+  private createSoloMuteRail(key: string, channelIndex: number, theme: number) {
+    const rail = document.createElement("div");
+    rail.className = `channel-rail theme-key-${theme}`;
+    const solo = this.createButton("TAP", "SOLO", channelIndex);
+    solo.className = "rail-solo";
+    solo.setAttribute("aria-label", `Solo ${key}`);
+    const mute = this.createButton("TAP", "MUTE", channelIndex);
+    mute.className = "rail-mute";
+    mute.setAttribute("aria-label", `Mute ${key}`);
+    rail.appendChild(solo);
+    rail.appendChild(mute);
+    this.channelRails[key] = { element: rail, solo, mute };
+    return rail;
+  }
+
+  private attachPadsChannel() {
+    const wrapper = this.createChannelWrapper("pads", this.elementPads);
+    const rail = document.createElement("div");
+    rail.className = `channel-rail theme-key-${this.core.theme}`;
+    rail.appendChild(this.elementEditorToggle);
+    wrapper.appendChild(rail);
+    this.padsRail = rail;
+  }
+
+  private attachKeysChannel() {
+    const wrapper = this.createChannelWrapper("keys", this.elementKeys);
+    wrapper.appendChild(
+      this.createSoloMuteRail("keys", this.sequencers.length, this.keys.theme)
+    );
+  }
+
+  updateChannelStates(states: RendererChannelState[]) {
+    states.forEach(({ key, muted, soloed, audible }) => {
+      const rail = this.channelRails[key];
+      if (!rail) return;
+      rail.solo.toggleAttribute("engaged", soloed);
+      rail.mute.toggleAttribute("engaged", muted);
+      this.channelWrappers[key]?.toggleAttribute("silenced", !audible);
+    });
   }
 
   setEditorOpen(open: boolean) {
@@ -134,9 +201,8 @@ export class Renderer {
     this.elementRoot.appendChild(this.style);
     this.setTheme(theme);
     this.initializeSequencers();
-    this.elementMain.appendChild(this.elementPads);
-    this.elementMain.appendChild(this.elementKeys);
-    this.elementMain.appendChild(this.elementEditorToggle);
+    this.attachPadsChannel();
+    this.attachKeysChannel();
     this.handleStepsSizeChange();
     this.refreshTheme();
   }
@@ -249,22 +315,38 @@ export class Renderer {
       element.className = `sequencer sequencer-${
         sequencer.isDrum() ? "drum" : "synth"
       } theme-key-${sequencer.theme}`;
+      const rail = this.channelRails[sequencer.key];
+      if (rail) {
+        rail.element.className = `channel-rail theme-key-${sequencer.theme}`;
+      }
     });
     this.elementKeys.className = `theme-key-${this.keys.theme}`;
     this.elementPads.className = `theme-key-${this.core.theme}`;
+    const keysRail = this.channelRails["keys"];
+    if (keysRail) {
+      keysRail.element.className = `channel-rail theme-key-${this.keys.theme}`;
+    }
+    if (this.padsRail) {
+      this.padsRail.className = `channel-rail theme-key-${this.core.theme}`;
+    }
   }
 
   initializeSequencers() {
     this.sequencerElements = {};
     this.sequencerButtons = {};
     this.activeColumns = {};
-    this.sequencers.forEach((sequencer) => {
+    this.channelRails = {};
+    this.channelWrappers = {};
+    this.sequencers.forEach((sequencer, index) => {
       const element = document.createElement("div");
       element.id = `sequencer-${sequencer.key}`;
       element.className = `sequencer sequencer-${
         sequencer.isDrum() ? "drum" : "synth"
       } theme-key-${sequencer.theme}`;
-      this.elementMain.appendChild(element);
+      const wrapper = this.createChannelWrapper(sequencer.key, element);
+      wrapper.appendChild(
+        this.createSoloMuteRail(sequencer.key, index, sequencer.theme)
+      );
       this.sequencerElements[sequencer.key] = element;
     });
   }
@@ -390,10 +472,10 @@ export class Renderer {
     let maxX = -Infinity;
     let maxY = -Infinity;
     this.elementMain.querySelectorAll("button").forEach((button) => {
-      // The editor toggle is chrome rather than part of the instrument's
-      // face — including it painted a pale full-width bar along the bottom
-      // and stretched the captured bounds to match.
-      if (button === this.elementEditorToggle) return;
+      // Rail controls (solo/mute, editor toggle) are chrome rather than part
+      // of the instrument's face — including them painted stray bars and
+      // stretched the captured bounds.
+      if (button.closest(".channel-rail")) return;
       const { top, right, bottom, left } = button.getBoundingClientRect();
       minX = Math.min(minX, left);
       minY = Math.min(minY, top);

--- a/machines/modulo/src/Sequencer.ts
+++ b/machines/modulo/src/Sequencer.ts
@@ -71,6 +71,10 @@ export class DrumSequencer extends SequencerBase {
     this.drums.dispose();
   }
 
+  setMuted(muted: boolean) {
+    this.drums.setMuted(muted);
+  }
+
   isDrum(): this is DrumSequencer {
     return true;
   }
@@ -111,6 +115,10 @@ export class SynthSequencer extends SequencerBase {
 
   dispose() {
     this.synths.dispose();
+  }
+
+  setMuted(muted: boolean) {
+    this.synths.setMuted(muted);
   }
 
   stop(time: number) {

--- a/machines/modulo/src/Synths.ts
+++ b/machines/modulo/src/Synths.ts
@@ -249,6 +249,9 @@ export class Synths {
   reverbSettings: SynthSettingsReverb;
   voices: ConfigurableSynth[] = [];
   volume: number;
+  // Mute lives outside `volume` so exports and the volume UI keep reporting
+  // the channel's set level while the output is silenced.
+  muted = false;
 
   constructor(
     {
@@ -304,7 +307,7 @@ export class Synths {
   }
 
   initialize({ mixer }: { mixer: Mixer }) {
-    this.output = new Gain(this.volume);
+    this.output = new Gain(this.muted ? 0 : this.volume);
     if (mixer.channel) this.output.connect(mixer.channel);
 
     this.bus = new Gain(1);
@@ -361,7 +364,14 @@ export class Synths {
   }
 
   getGain() {
-    return this.output ? this.output.gain.value : this.volume;
+    return this.volume;
+  }
+
+  setMuted(muted: boolean) {
+    this.muted = muted;
+    if (this.output) {
+      this.output.gain.value = muted ? 0 : this.volume;
+    }
   }
 
   updateDelay(updates: { wet?: number; delayTime?: Time; feedback?: number }) {
@@ -378,7 +388,7 @@ export class Synths {
   updateGain(gain: number) {
     this.volume = gain;
     if (this.output) {
-      this.output.gain.value = gain;
+      this.output.gain.value = this.muted ? 0 : gain;
     }
   }
 

--- a/machines/modulo/src/style/base.css
+++ b/machines/modulo/src/style/base.css
@@ -22,20 +22,16 @@ html.rainbow body {
   }
 }
 
-/* Mobile: the open editor covers the machine, except the toggle bar at the
-   bottom, which is the way back. */
+/* Mobile: the open editor covers the machine; the editor toggle in the pads
+   row's rail stays above the overlay as the way back. */
 prompt-interface {
   --page-padding-x: calc(var(--pads-padding-x-factor) * var(--size-unit));
   --page-padding-y: calc(var(--pads-padding-y-factor) * var(--size-unit));
-  --page-gap-y: calc(var(--pads-gap-y-factor) * var(--size-unit));
 
   background: var(--color-page);
-  /* clears the toggle bar and the machine's own gap below the keys */
-  bottom: calc(
-    var(--page-padding-y) + var(--editor-bar-height) + var(--page-gap-y)
-  );
+  bottom: 0;
   left: 0;
-  padding: var(--page-padding-y) var(--page-padding-x) 0;
+  padding: var(--page-padding-y) var(--page-padding-x);
   position: fixed;
   right: 0;
   top: 0;
@@ -46,17 +42,11 @@ prompt-interface {
   }
 }
 
-/* The editor toggle: a short, wordless full-width bar below the keyboard. */
+/* The editor toggle lives in the pads row's rail; base look comes from
+   .channel-rail > button. */
 #editor-toggle {
-  background: var(--color-background);
-  border-radius: calc(var(--pads-corner-factor) * var(--size-unit) * 0.5);
-  flex-shrink: 0;
-  height: var(--editor-bar-height);
-  opacity: 0.5;
-  width: 100%;
   z-index: 11;
 
-  &:hover,
   &[open] {
     opacity: 1;
   }

--- a/machines/modulo/src/style/pads.css
+++ b/machines/modulo/src/style/pads.css
@@ -200,27 +200,74 @@ main[stepping="true"] .sequencer {
   }
 }
 
-.sequencer {
+/* Each row of the machine — sequencers, pads, keys — pairs its section with
+   a rail of controls on the right. */
+.channel {
   display: flex;
-  flex-direction: column;
-  gap: calc(var(--pads-gap-y-factor) * var(--size-unit));
-  width: 100%;
+  gap: calc(var(--pads-gap-x-factor) * var(--size-unit));
+  min-height: 0;
 
-  &:has(> :last-child:nth-child(1)) {
+  &:has(> .sequencer > :last-child:nth-child(1)),
+  &:has(> #pads) {
     flex: 1;
   }
-  &:has(> :last-child:nth-child(2)) {
+  &:has(> .sequencer > :last-child:nth-child(2)),
+  &:has(> #keys) {
     flex: 2;
   }
-  &:has(> :last-child:nth-child(3)) {
+  &:has(> .sequencer > :last-child:nth-child(3)) {
     flex: 3;
   }
-  &:has(> :last-child:nth-child(4)) {
+  &:has(> .sequencer > :last-child:nth-child(4)) {
     flex: 4;
   }
-  &:has(> :last-child:nth-child(5)) {
+  &:has(> .sequencer > :last-child:nth-child(5)) {
     flex: 5;
   }
+
+  &[silenced] > .sequencer,
+  &[silenced] > #keys {
+    opacity: 0.35;
+  }
+}
+
+.channel-rail {
+  display: flex;
+  flex-direction: column;
+  flex-shrink: 0;
+  gap: calc(var(--pads-gap-y-factor) * var(--size-unit) * 0.5);
+  width: var(--rail-size);
+
+  > button {
+    background: oklch(
+      var(--color-b-lit) var(--color-b-chr)
+        calc(var(--color-hue-base) + var(--color-b-hue)) / 1
+    );
+    border-radius: calc(var(--pads-corner-factor) * var(--size-unit) * 0.5);
+    flex: 1;
+    opacity: 0.5;
+    position: relative;
+
+    &:hover {
+      opacity: 1;
+    }
+
+    &[engaged] {
+      background: oklch(
+        var(--color-a-lit) var(--color-a-chr)
+          calc(var(--color-hue-base) + var(--color-a-hue)) / 1
+      );
+      opacity: 1;
+    }
+  }
+}
+
+.sequencer {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  gap: calc(var(--pads-gap-y-factor) * var(--size-unit));
+  min-width: 0;
 
   > div {
     display: flex;
@@ -238,9 +285,9 @@ main[stepping="true"] .sequencer {
     1 / 14 * 100% - (var(--pads-gap-x-factor) * var(--size-unit)) * 13 / 14
   );
   display: flex;
-  flex: 2;
+  flex: 1;
+  min-width: 0;
   position: relative;
-  width: 100%;
 
   > button {
     --border-radius: calc(var(--pads-corner-factor) * var(--size-unit) * 0.25)
@@ -343,7 +390,7 @@ main[stepping="true"] .sequencer {
   flex-wrap: wrap;
   gap: calc(var(--pads-gap-x-factor) * var(--size-unit));
   flex: 1;
-  width: 100%;
+  min-width: 0;
   z-index: 2;
 
   > button {

--- a/machines/modulo/src/style/theme.css
+++ b/machines/modulo/src/style/theme.css
@@ -56,7 +56,7 @@
   );
 
   --size-unit: 1rem;
-  --editor-bar-height: calc(var(--size-unit) * 1);
+  --rail-size: calc(var(--size-unit) * 1);
 
   --font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
     Roboto, Oxygen, Ubuntu, Cantarell, "Open Sans", "Helvetica Neue", sans-serif;

--- a/packages/amplib-steganography/src/Stegassette/Img.ts
+++ b/packages/amplib-steganography/src/Stegassette/Img.ts
@@ -95,10 +95,15 @@ export function getBorderPixels(
 
 /**
  * Number of data pixels (checkerboard) in an IW×IH interior.
- * O(1) formula; used to allocate exact Uint32Array paths.
+ * Even rows (y even) hold floor(W/2) data pixels (x odd); odd rows hold
+ * ceil(W/2) (x even). O(1); used to allocate exact Uint32Array paths — an
+ * over-count leaves phantom (0,0) entries at the tail of the path, which
+ * write payload onto a key pixel at exact-capacity fills.
  */
 export function dataPixelCount(W: number, H: number): number {
-  return Math.floor(W / 2) * H + (W % 2 === 0 ? 0 : Math.ceil(H / 2));
+  return (
+    Math.floor(W / 2) * Math.ceil(H / 2) + Math.ceil(W / 2) * Math.floor(H / 2)
+  );
 }
 
 /** Number of border pixels in a W×H image with border width B. */

--- a/packages/amplib-steganography/src/Stegassette/keymap.ts
+++ b/packages/amplib-steganography/src/Stegassette/keymap.ts
@@ -24,41 +24,50 @@ export const KEYMAP_NAMES: readonly KeymapName[] = [
 ];
 
 /**
- * Snap a target (px, py) to the nearest key pixel if it happens to land on a
- * data pixel. Adjacent fallback is determined by row parity.
+ * Snap a target (px, py) to the nearest IN-INTERIOR key pixel. Keys must never
+ * land on the border ring: the STGC header rewrites ring alpha, and canvases
+ * premultiply-round the RGB of any pixel with alpha < 255, which silently
+ * corrupts whatever bytes were keyed against it.
  */
-function snapToKey(px: number, py: number): [number, number] {
+function snapToKey(px: number, py: number, IW: number, IH: number): [number, number] {
   if (!isDataPixel(px, py)) return [px, py];
-  return py % 2 === 0 ? [px - 1, py] : [px + 1, py];
+  const first = py % 2 === 0 ? px - 1 : px + 1;
+  if (first >= 0 && first < IW) return [first, py];
+  const second = py % 2 === 0 ? px + 1 : px - 1;
+  if (second >= 0 && second < IW) return [second, py];
+  // 1-wide interior: the row holds no key pixel, so step to the row above/below
+  // (checkerboard parity flips, making the same x a key pixel there).
+  return [px, py > 0 ? py - 1 : Math.min(py + 1, IH - 1)];
 }
 
 export const KEYMAP: Record<KeymapName, KeymapFn> = {
-  // one pixel left on even rows, one right on odd rows (always lands on a key pixel)
-  adjacent: (dx, dy) => (dy % 2 === 0 ? [dx - 1, dy] : [dx + 1, dy]),
+  // one pixel left on even rows, one right on odd rows, reflected back inside
+  // the interior at the edges (always lands on an in-bounds key pixel)
+  adjacent: (dx, dy, IW, IH) => snapToKey(dx, dy, IW, IH),
 
   // diagonally opposite corner (180° rotation), then snap to nearest key pixel
   poles: (dx, dy, IW, IH) =>
-    snapToKey(IW - 1 - dx, IH - 1 - dy),
+    snapToKey(IW - 1 - dx, IH - 1 - dy, IW, IH),
 
   // horizontally flipped, then snap to nearest key pixel
-  "mirror-x": (dx, dy, IW) =>
-    snapToKey(IW - 1 - dx, dy),
+  "mirror-x": (dx, dy, IW, IH) =>
+    snapToKey(IW - 1 - dx, dy, IW, IH),
 
   // vertically flipped, then snap to nearest key pixel
-  "mirror-y": (dx, dy, _IW, IH) =>
-    snapToKey(dx, IH - 1 - dy),
+  "mirror-y": (dx, dy, IW, IH) =>
+    snapToKey(dx, IH - 1 - dy, IW, IH),
 
   // data position + (kx, ky) wrapped torus-style, snap to nearest key pixel
   offset: (dx, dy, IW, IH, p = {}) => {
     const ox = (((dx + (p.kx ?? 0)) % IW) + IW) % IW;
     const oy = (((dy + (p.ky ?? 0)) % IH) + IH) % IH;
-    return snapToKey(ox, oy);
+    return snapToKey(ox, oy, IW, IH);
   },
 
   // 90° clockwise rotation (aspect-normalized), snap to nearest key pixel
   rotate: (dx, dy, IW, IH) => {
     const px = Math.round((1 - (IH > 1 ? dy / (IH - 1) : 0)) * (IW - 1));
     const py = Math.round((IW > 1 ? dx / (IW - 1) : 0) * (IH - 1));
-    return snapToKey(px, py);
+    return snapToKey(px, py, IW, IH);
   },
 };


### PR DESCRIPTION
## What changed

### Modulo: per-channel solo/mute rail
Every row of the machine now pairs its section with a slot on a right-side rail:

- **lead, arp, bass, kit, keys** each get a stacked split button — top half solos, bottom half mutes. Engaged buttons fill with the channel's accent color; channels silenced by mute (or by another channel's solo) dim to 35%.
- **pads row** holds the editor toggle in the same slot, replacing the full-width bar below the keyboard. On mobile the open editor covers the screen and the toggle stays clickable above the overlay as the way back.

Mute is session-only: it zeroes the channel's output gain without touching the stored volume, so saves, exports, and the volume UI keep reporting the set level. `Machine` re-applies rail state after every update (sequencers/keys are rebuilt each time), and rail buttons are excluded from settings-image snapshots like the old toggle was.

### Stegassette: two payload-corruption bugs at interior edges
Both surfaced as a single flipped byte (always XOR 0x7F) in exported settings images with odd interior widths — one specific patch decoded corrupt twice in a row before this:

1. **Keymaps could walk onto the border ring.** Edge data pixels on odd rows mapped to a key pixel outside the interior. The STGC header rewrites ring alpha, and canvas `toDataURL` premultiply-rounds the RGB of non-opaque pixels — silently changing the key under an encoded byte. `snapToKey` now reflects back inside the interior (vertical fallback for 1-wide interiors) and every keymap routes through it.
2. **`dataPixelCount` off-by-one for odd×odd interiors.** The over-count left a phantom (0,0) entry at the tail of every traversal path; at exact-capacity fills the encoder wrote payload onto that key pixel, corrupting the stream head.

## Verification

- Formula brute-verified against actual checkerboard counts for all 1,600 sizes up to 40×40.
- 270-run encode/decode sweep (every traversal × keymap, odd/even geometries, exact-capacity fills, simulated canvas premultiplication) passes clean; previously failing cases reproduced deterministically before the fix.
- Rail exercised in the live app: solo/mute state math, engaged/dimmed rendering, mobile overlay z-order, and six full settings-image export/decode round-trips through the new UI.

## Reviewer notes

- The keymap change alters which key pixel edge bytes use, so pre-fix images with odd interior widths may fail to decode at those positions — they were already unreliable (the corruption depended on pixel values), and per earlier direction the format carries no backward-compat fallbacks.
- `Synths.getGain()`/`Drums` export now report the tracked `volume` field rather than the live gain node value, which is what keeps mute out of persisted state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)